### PR TITLE
Fix license

### DIFF
--- a/satysfi-fonts-noto-sans-cjk-sc.opam
+++ b/satysfi-fonts-noto-sans-cjk-sc.opam
@@ -9,7 +9,7 @@ This package installs fonts from https://www.google.com/get/noto/.
 """
 maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
 authors: "Naoki Kaneko <puripuri2100@gmail.com>"
-license: "OFL"
+license: "OFL-1.1"
 homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.git"


### PR DESCRIPTION
Noto is licensed under OFL-1.1.